### PR TITLE
Fix Parsing Issue with Negative Numbers in Delimited String

### DIFF
--- a/gridparse/utils.py
+++ b/gridparse/utils.py
@@ -1,4 +1,5 @@
 import argparse
+import re
 from typing import Callable
 
 
@@ -20,7 +21,9 @@ def list_as_dashed_str(actual_type: Callable, delimiter: str = "-"):
     def _list_of_lists(s: str):
         if s == "None":
             return None
-        l = [actual_type(e) for e in s.split(delimiter)]
+        pattern = fr'(?:(?<!\d)-)?\d+'
+        elements = re.findall(pattern,s)
+        l = [actual_type(e) for e in elements]
         return l
 
     return _list_of_lists


### PR DESCRIPTION
-  Corrected the bug in parsing negative numbers in the delimited string.
-  Rather than splitting by the delimiter straight off which messes up with negative numbers are present (e.g., "-1-2-3" being split up wrongly as ['', '1', '2', '3'],
-  we now utilize a regex pattern to match proper numbers (including those with negative starters).
- The regex `(?:(?<!\\d)-)?\\d+` makes sure negative signs are included as part of the number and not as a delimiter, allowing proper handling of cases like "-1-2--3".