### PR TITLE
Improve argument parsing with `list_as_delim_str`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.3] - 2025-03-20
+
+## Fixed
+- Bug with negative numbers in lists as strs
+
+## Changes
+- Delimiter of `nargs` of searchable argument from `~~` to `|`
+- Util name form `list_as_dashed_str` to `list_as_delim_str`
+- Default delimiter in (now) `list_as_delim_str` changed to `,` (avoids errors with negative numbers)
+
 ## [1.5.2] - 2025-03-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,20 +51,20 @@ parser.add_argument(
     "--lists",
     required=True,
     nargs="+",
-    type=list_as_dashed_str(int),
+    type=list_as_delim_str(int),
     searchable=True,
 )
 parser.add_argument(
     "--normal_lists",
     required=True,
     nargs="+",
-    type=list_as_dashed_str(str),
+    type=list_as_delim_str(str),
 )
 args = parser.parse_args(
     (
-        "--hparam1 1 2 3 --hparam2 4~~3 5~~4 6~~5 "
-        "--normal efrgthytfgn --lists 1-2-3 3-4-5~~6-7 "
-        "--normal_lists 1-2-3 4-5-6"
+        "--hparam1 1 2 3 --hparam2 4|3 5|4 6|5 "
+        "--normal efrgthytfgn --lists 1,-2,3 3,4,5|6,7 "
+        "--normal_lists a,b,c d,e,f"
     ).split()
 )
 assert len(args) == 3 * 3 * 1 * 2 * 1  # corresponding number of different values in input CL arguments
@@ -91,6 +91,11 @@ Namespace(hparam1=[1, 2, 3], hparam2=[6, 5], lists=[['3', '4', '5'], ['6', '7']]
 
 ]
 ```
+
+Searchable argument always use space to designate a different configuration. Namely, notice that for:
+- `nargs` and `searchable=True`, `nargs` is delimited by `|` and `searchable` uses the spaces.
+- `nargs` and `searchable=True` and `list_as_delim_str`, `nargs` uses `|` within each configuration, and `list_as_delim_str` uses `,` within each list of the same configuration, and space is still used by `searchable` to split configurations.
+
 
 ## Additional capabilities
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ parser.add_argument(
     "--lists",
     required=True,
     nargs="+",
-    type=list_as_dashed_str(str),
+    type=list_as_dashed_str(int),
     searchable=True,
 )
 parser.add_argument(
@@ -62,12 +62,12 @@ parser.add_argument(
 )
 args = parser.parse_args(
     (
-        "--hparam1 1~~2~~3 --hparam2 4~~3 5~~4 6~~5 "
+        "--hparam1 1 2 3 --hparam2 4~~3 5~~4 6~~5 "
         "--normal efrgthytfgn --lists 1-2-3 3-4-5~~6-7 "
         "--normal_lists 1-2-3 4-5-6"
     ).split()
 )
-assert len(args) == 1 * 3 * 1 * 2 * 1  # corresponding number of different values in input CL arguments
+assert len(args) == 3 * 3 * 1 * 2 * 1  # corresponding number of different values in input CL arguments
 
 pprint(args)
 ```

--- a/gridparse/__init__.py
+++ b/gridparse/__init__.py
@@ -1,4 +1,4 @@
 from argparse import *
 
 from .grid_argument_parser import GridArgumentParser
-from .utils import list_as_dashed_str, strbool
+from .utils import list_as_delim_str, strbool

--- a/gridparse/grid_argument_parser.py
+++ b/gridparse/grid_argument_parser.py
@@ -5,7 +5,7 @@ from typing import Any, Tuple, List, Optional, Union, Sequence
 from copy import deepcopy
 from omegaconf import OmegaConf
 
-from gridparse.utils import list_as_dashed_str, strbool
+from gridparse.utils import list_as_delim_str, strbool
 
 
 class AuxArgumentParser(argparse.ArgumentParser):
@@ -710,7 +710,7 @@ class GridArgumentParser(_GridActionsContainer, AuxArgumentParser):
             type = kwargs.get("type", None)
 
             if nargs == "+":
-                type = list_as_dashed_str(type, delimiter="~~")
+                type = list_as_delim_str(type, delimiter="|")
             else:
                 nargs = "+"
 

--- a/gridparse/utils.py
+++ b/gridparse/utils.py
@@ -2,12 +2,12 @@ import argparse
 from typing import Callable
 
 
-# TODO: has issues with negative numbers
-def list_as_dashed_str(actual_type: Callable, delimiter: str = "-"):
+# NOTE: has issues with negative numbers if delim="-"
+def list_as_delim_str(actual_type: Callable, delimiter: str = ","):
     """Creates a function that converts a string to a list of elements.
 
     Can be used as the `type` argument in `argparse` to convert
-    a string to a list of elements, e.g.: `["1-2-3", "4-5-6"]` to
+    a string to a list of elements, e.g.: `["1,2,3", "4,5,6"]` to
     `[[1, 2, 3], [4, 5, 6]]` (note that this operates on a single
     `str` at a time, use `nargs` to pass multiple).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridparse"
-version = "1.5.2"
+version = "1.5.3"
 description = "Grid search directly from argparse"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="gridparse",
-    version="1.5.2",
+    version="1.5.3",
     description="Grid search directly from argparse",
     author="Georgios Chochlakis",
     author_email="georgioschochlakis@gmail.com",


### PR DESCRIPTION
Fixes #1 
- Delimiter by default now is `,` for `list_as_delim_str` (used to be `list_as_dashed_str`), which does not create errors with negative numbers
- Changes delimiter for `nargs` from cumbersome `~~` to `|`